### PR TITLE
Replace object elements with img

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -206,10 +206,10 @@
 
     <figure id="figure1">
       <!-- Source for this file is at https://docs.google.com/drawings/d/1IJuh-WWpk_jIgzNpnnZN6d-ezTFv9k03o59GQBIeo58 -->
-      <object data="figure1.svg" style="width: 100%" type="image/svg+xml" aria-describedby="figure1-alt">
-        <p id="figure1-alt">The image represents the graph described in <a href="#example4"></a>.</p>
-      </object>
-      <figcaption>Graph for RDF/XML Example</figcaption>
+      <img src="figure1.svg" style="width: 100%" type="image/svg+xml" aria-describedby="figure1-alt" />
+      <figcaption id="figure1-alt">Graph for RDF/XML Example
+        described in <a href="#example4"></a>.
+      </figcaption>
     </figure>
 
     <p>An RDF graph is given in <a href="#figure1">Figure 1</a>
@@ -222,15 +222,13 @@
 
     <figure id="figure2">
       <!-- Source for this file is at https://docs.google.com/drawings/d/1oQjG8DyfGr33UnaCrS7nC96JMt3NI7Jv2v5LfLUZcYE -->
-      <object data="figure2.svg" style="width: 100%" type="image/svg+xml" aria-describedby="figure2-alt">
-        <p id="figure2-alt">
-          The image represents the graph described in <a href="#example4"></a>
-          highlighting the path from `&lt;http://www.w3.org/TR/rdf-syntax-grammar>`
-          to `&lt;http://purl.org/net/dajobe>`.
-          Elements along the path are marked in <strong>bold text</strong>.
-        </p>
-      </object>
-      <figcaption>One Path Through the Graph</figcaption>
+      <img src="figure2.svg" style="width: 100%" type="image/svg+xml" aria-describedby="figure2-alt" />
+      <figcaption>One Path Through the Graph
+        described in <a href="#example4"></a>
+        highlighting the path from `&lt;http://www.w3.org/TR/rdf-syntax-grammar>`
+        to `&lt;http://purl.org/net/dajobe>`.
+        Elements along the path are marked in <strong>bold text</strong>.
+      </figcaption>
     </figure>
 
     <p>The left hand side of the <a href="#figure2">Figure 2</a>

--- a/spec/index.html
+++ b/spec/index.html
@@ -206,7 +206,8 @@
 
     <figure id="figure1">
       <!-- Source for this file is at https://docs.google.com/drawings/d/1IJuh-WWpk_jIgzNpnnZN6d-ezTFv9k03o59GQBIeo58 -->
-      <img src="figure1.svg" style="width: 100%" type="image/svg+xml" aria-describedby="figure1-alt" />
+      <img src="figure1.svg" style="width: 100%" aria-describedby="figure1-alt"
+         alt="Graph for RDF/XML Example 4." />
       <figcaption id="figure1-alt">Graph for RDF/XML Example
         described in <a href="#example4"></a>.
       </figcaption>
@@ -222,8 +223,9 @@
 
     <figure id="figure2">
       <!-- Source for this file is at https://docs.google.com/drawings/d/1oQjG8DyfGr33UnaCrS7nC96JMt3NI7Jv2v5LfLUZcYE -->
-      <img src="figure2.svg" style="width: 100%" type="image/svg+xml" aria-describedby="figure2-alt" />
-      <figcaption>One Path Through the Graph
+      <img src="figure2.svg" style="width: 100%" aria-describedby="figure2-alt"
+         alt="One path through the graph for RDF/XML Example 4." />
+      <figcaption id="figure2-alt">One Path Through the Graph
         described in <a href="#example4"></a>
         highlighting the path from `&lt;http://www.w3.org/TR/rdf-syntax-grammar>`
         to `&lt;http://purl.org/net/dajobe>`.


### PR DESCRIPTION
and fold the description in to the figure caption.

Fixes #9.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/pull/14.html" title="Last updated on Mar 28, 2023, 12:56 AM UTC (46c955f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/14/da65ed7...46c955f.html" title="Last updated on Mar 28, 2023, 12:56 AM UTC (46c955f)">Diff</a>