### PR TITLE
Update/fix XMLSCHEMA references (parts 1 and 2) to XMLSCHEMA11.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -647,7 +647,7 @@
     typed literal
     ("123", <code>http://www.w3.org/2001/XMLSchema#int</code>)
     to be interpreted as an
-    XML Schema [[XMLSCHEMA-2]] datatype <code>int</code>.
+    XML Schema [[XMLSCHEMA11-2]] datatype <a data-cite="XMLSCHEMA11-2#int"><code>int</code></a>.
     </p>
 
     <aside class="example" id="example10" title="Complete example of rdf:datatype">
@@ -2005,8 +2005,8 @@
 
       <p class="note" id="literal-white-space-normalization-note">
         <strong>Implementation Note (Informative): </strong>
-        In XML Schema (part 1) [[XMLSCHEMA-1]],
-        <a data-cite="XMLSCHEMA-1#d0e1654">
+        In XML Schema (part 1) [[XMLSCHEMA11-1]],
+        <a data-cite="XMLSCHEMA11-1#sec-wsnormalization">
           white space normalization
         </a>
         occurs during validation according to the value of the whiteSpace


### PR DESCRIPTION
Fixes a reference to XMLSCHEMA-1 (for part 1), and XMLSCHEMA1-2 (for part 2).

Relates to https://github.com/w3c/sparql-query/pull/85.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/pull/32.html" title="Last updated on May 29, 2023, 8:03 AM UTC (f7ed55e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/32/8d0fafb...f7ed55e.html" title="Last updated on May 29, 2023, 8:03 AM UTC (f7ed55e)">Diff</a>