### PR TITLE
Updates test suite location.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -12,7 +12,7 @@
       specStatus:           "ED",
       edDraftURI:           "https://w3c.github.io/rdf-xml/spec/",
       shortName:            "rdf12-xml",
-      testSuiteURI:         "https://w3c.github.io/rdf-tests/rdf-xml/",
+      testSuiteURI:         "https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-xml/",
       copyrightStart:       "2004",
 
       previousPublishDate:  "2014-02-25",


### PR DESCRIPTION
Updated locateion is https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-xml/, which are the RDF 1.1 tests; there are no new tests for RDF 1.2.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/pull/45.html" title="Last updated on Nov 3, 2023, 8:13 PM UTC (6bb286f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/45/cab62cc...6bb286f.html" title="Last updated on Nov 3, 2023, 8:13 PM UTC (6bb286f)">Diff</a>