### PR TITLE
Remove class=informative from subsections of informative section

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -166,7 +166,7 @@
   </p>
 
     <!-- intro -->
-  <section id="section-Syntax-intro" class="informative">
+  <section id="section-Syntax-intro">
     <h3>Introduction</h3>
 
     <p>The RDF Concepts and Abstract Syntax document [[RDF12-CONCEPTS]]
@@ -233,7 +233,7 @@
   </section>
 
   <!-- node and property elements -->
-  <section id="section-Syntax-node-property-elements" class="informative">
+  <section id="section-Syntax-node-property-elements">
     <h3>Node Elements and Property Elements</h3>
 
     <figure id="figure1">
@@ -364,7 +364,7 @@
   </section>
 
   <!-- multiple properties -->
-  <section id="section-Syntax-multiple-property-elements" class="informative">
+  <section id="section-Syntax-multiple-property-elements">
     <h3>Multiple Property Elements</h3>
 
     <p>There are several abbreviations that can be used to make common
@@ -407,7 +407,7 @@
   </section>
 
   <!-- empty property elements -->
-  <section id="section-Syntax-empty-property-elements" class="informative">
+  <section id="section-Syntax-empty-property-elements">
     <h3>Empty Property Elements</h3>
 
     <p>When a predicate arc in an <a data-cite="RDF12-CONCEPTS#dfn-rdf-graph">RDF graph</a> points to an object node which has no
@@ -445,7 +445,7 @@
   </section>
 
   <!-- empty property attributes -->
-  <section id="section-Syntax-property-attributes" class="informative">
+  <section id="section-Syntax-property-attributes">
     <h3>Property Attributes</h3>
 
     <p>When a <a data-lt="property element">property element's</a> content is string literal,
@@ -489,7 +489,7 @@
   </section>
 
   <!-- complete rdf/xml document -->
-  <section id="section-Syntax-complete-document" class="informative">
+  <section id="section-Syntax-complete-document">
     <h3>Completing the Document: Document Element and XML Declaration</h3>
 
     <p>To create a complete RDF/XML document, the serialization of the
@@ -548,7 +548,7 @@
   </section>
 
   <!-- language attribute -->
-  <section id="section-Syntax-languages" class="informative">
+  <section id="section-Syntax-languages">
     <h3>Languages: <code>xml:lang</code></h3>
 
     <p>RDF/XML permits the use of the <code>xml:lang</code> attribute as defined by
@@ -599,7 +599,7 @@
   </section>
 
   <!-- dir attribute -->
-  <section id="section-Syntax-base-direction" class="informative">
+  <section id="section-Syntax-base-direction">
     <h3>Base Direction: <code>its:dir</code></h3>
 
     <p>RDF 1.2 introduces the concept of a <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a> which can be used
@@ -645,7 +645,7 @@
   </section>
 
   <!-- XML Literal -->
-  <section id="section-Syntax-XML-literals" class="informative">
+  <section id="section-Syntax-XML-literals">
     <h3>XML Literals: <code>rdf:parseType="Literal"</code></h3>
 
     <p>RDF allows XML literals [RDF12-CONCEPTS]
@@ -693,7 +693,7 @@
   </section>
 
   <!-- datatyped literals -->
-  <section id="section-Syntax-datatyped-literals" class="informative">
+  <section id="section-Syntax-datatyped-literals">
     <h3>Typed Literals: <code>rdf:datatype</code></h3>
 
     <p>RDF allows typed literals
@@ -743,7 +743,7 @@
   </section>
 
   <!-- blank nodes -->
-  <section id="section-Syntax-blank-nodes" class="informative">
+  <section id="section-Syntax-blank-nodes">
     <h3>Identifying Blank Nodes: <code>rdf:nodeID</code></h3>
 
     <p><a data-cite="RDF12-CONCEPTS#dfn-blank-node">Blank nodes</a> in the RDF are distinct but have no
@@ -796,7 +796,7 @@
   </section>
 
   <!-- parsetype resource -->
-  <section id="section-Syntax-parsetype-resource" class="informative">
+  <section id="section-Syntax-parsetype-resource">
     <h3>Omitting Blank Nodes: <code>rdf:parseType="Resource"</code></h3>
 
     <p><a data-cite="RDF12-CONCEPTS#dfn-blank-node">Blank nodes</a> (not <a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a> nodes) in <a data-cite="RDF12-CONCEPTS#dfn-rdf-graph">RDF graphs</a> can be written
@@ -840,7 +840,7 @@
   </section>
 
   <!-- attributes on property elements -->
-  <section id="section-Syntax-property-attributes-on-property-element" class="informative">
+  <section id="section-Syntax-property-attributes-on-property-element">
     <h3>Omitting Nodes: Property Attributes on an empty Property Element</h3>
 
     <p>
@@ -891,7 +891,7 @@
   </section>
 
   <!-- typed nodes -->
-  <section id="section-Syntax-typed-nodes" class="informative">
+  <section id="section-Syntax-typed-nodes">
     <h3>Typed Node Elements</h3>
 
     <p id="typed-nodes-tests1" data-tests="
@@ -962,7 +962,7 @@
   </section>
 
   <!-- xml base -->
-  <section id="section-Syntax-ID-xml-base" class="informative">
+  <section id="section-Syntax-ID-xml-base">
     <h3>Abbreviating IRIs: <code>rdf:ID</code> and <code>xml:base</code></h3>
 
     <p>RDF/XML allows further abbreviating <a data-cite="RDF12-CONCEPTS#dfn-iri">IRIs</a> in XML attributes in two
@@ -1024,7 +1024,7 @@
   </section>
 
   <!-- list elements -->
-  <section id="section-Syntax-list-elements" class="informative">
+  <section id="section-Syntax-list-elements">
     <h3>Container Membership Property Elements: <code>rdf:li</code> and <code>rdf:_</code><em>n</em></h3>
 
     <p id="list-elements-tests1" data-tests="
@@ -1096,7 +1096,7 @@
   </section>
 
   <!-- parsetype collection -->
-  <section id="section-Syntax-parsetype-Collection" class="informative">
+  <section id="section-Syntax-parsetype-Collection">
     <h3>Collections: <code>rdf:parseType="Collection"</code></h3>
 
     <p>RDF/XML allows an <code>rdf:parseType="Collection"</code>
@@ -1143,7 +1143,7 @@
   </section>
 
   <!-- reification -->
-  <section id="section-Syntax-reifying" class="informative">
+  <section id="section-Syntax-reifying">
     <h3>Reifying Statements: <code>rdf:ID</code></h3>
 
     <p>The <code>rdf:ID</code> attribute can be used on a property
@@ -1189,7 +1189,7 @@
 
   </section>
 
-  <section id="section-Syntax-triple-terms" class="informative">
+  <section id="section-Syntax-triple-terms">
     <h3>Triple Terms: <code>rdf:parseType="Triple"</code></h3>
 
     <p>A <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>
@@ -1236,7 +1236,7 @@
       asserting and describing a triple at the same time.</p>
   </section>
 
-  <section id="section-Syntax-annotations" class="informative">
+  <section id="section-Syntax-annotations">
     <h3>Annotating Triples: `rdf:annotation` or `rdf:annotationNodeID`</h3>
 
     <p>RDF 1.2 XML Syntax also includes syntax for


### PR DESCRIPTION
Section 2 is a description of RDF/XML features. It non-normative.

The subsections are therefore non-normative so they don't need to repeat the statement.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/pull/75.html" title="Last updated on Dec 4, 2025, 7:16 PM UTC (efeff96)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/75/3dd34f3...efeff96.html" title="Last updated on Dec 4, 2025, 7:16 PM UTC (efeff96)">Diff</a>