### PR TITLE
Fix link text

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1348,7 +1348,7 @@
       on an in-scope <a>node element</a> with an `rdf:version` attribute
       with a defined value other than `"1.1"`.
       Acceptable values for `rdf:version` are defined in
-      <a data-cite="RDF12-CONCEPTS#defined-version-labels">2.1 Version Lables</a> in [[RDF12-CONCEPTS]].
+      <a data-cite="RDF12-CONCEPTS#defined-version-labels">2.1 Version Labels</a> in [[RDF12-CONCEPTS]].
       Parser behavior for version values is otherwise undefined and MAY be used
       to signal errors or warnings.
       </p>


### PR DESCRIPTION
"Lable" -> "Label"


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/pull/78.html" title="Last updated on Dec 19, 2025, 8:59 AM UTC (8167815)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/78/249b2a6...8167815.html" title="Last updated on Dec 19, 2025, 8:59 AM UTC (8167815)">Diff</a>