### PR TITLE
Fixes wrong rdf:annotationAttr and rdf:annotationNodeIDAttr attribute names

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -3787,7 +3787,7 @@ to this sequence to give an xsd:string <em>x</em>.</li>
     <h4>Production annotationAttr</h4>
 
     <div class="productionOuter"><div class="productionInner"><p>
-    attribute(<a href="#eventterm-attribute-URI">IRI</a> == <code>rdf:annotationAttr</code>,<br />
+    attribute(<a href="#eventterm-attribute-URI">IRI</a> == <code>rdf:annotation</code>,<br />
     &#160;&#160;&#160;&#160;<a href="#eventterm-attribute-string-value">string-value</a> == string(<a href="#URI-reference">IRI</a>))
 
     </p></div></div>
@@ -3802,7 +3802,7 @@ to this sequence to give an xsd:string <em>x</em>.</li>
     <h4>Production annotationNodeIDAttr</h4>
 
     <div class="productionOuter"><div class="productionInner"><p>
-    attribute(<a href="#eventterm-attribute-URI">IRI</a> == <code>rdf:annotationNodeIDAttr</code>,<br />
+    attribute(<a href="#eventterm-attribute-URI">IRI</a> == <code>rdf:annotationNodeID</code>,<br />
     &#160;&#160;&#160;&#160;<a href="#eventterm-attribute-rdf-term">rdf-term</a> == bnodeid(<a href="#rdf-id">rdf-id</a>))
 
     </p></div></div>


### PR DESCRIPTION
Typos in the production spec


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/pull/81.html" title="Last updated on Jan 10, 2026, 3:59 PM UTC (adb6e5d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/81/1bef8f1...adb6e5d.html" title="Last updated on Jan 10, 2026, 3:59 PM UTC (adb6e5d)">Diff</a>