### PR TITLE
Add an Orcid for former editors: Fabien, Guus and Ralph

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -45,11 +45,11 @@
       ],
 
       formerEditors:  [
-        { name: "Fabien Gandon" },
-        { name: "Guus Schreiber" },
+        { name: "Fabien Gandon" , orcid: "0000-0003-0543-1232"},
+        { name: "Guus Schreiber", orcid: "0000-0002-2400-1185" },
         { name: "Dave Beckett"},
         { name: "Ora Lassilla"},
-        { name: "Ralph Swick"},
+        { name: "Ralph Swick", orcid: "0000-0002-5617-3248"},
       ],
 
       authors: [

--- a/spec/index.html
+++ b/spec/index.html
@@ -48,7 +48,7 @@
         { name: "Fabien Gandon" , orcid: "0000-0003-0543-1232"},
         { name: "Guus Schreiber", orcid: "0000-0002-2400-1185" },
         { name: "Dave Beckett"},
-        { name: "Ora Lassilla"},
+        { name: "Ora Lassilla", orcid: "0000-0002-0001-9137"},
         { name: "Ralph Swick", orcid: "0000-0002-5617-3248"},
       ],
 


### PR DESCRIPTION
Not really important but for the former editors that have an Orcid they now have it as an id attached to their names.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/pull/83.html" title="Last updated on Apr 2, 2026, 4:41 PM UTC (4b73330)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/83/40c9080...4b73330.html" title="Last updated on Apr 2, 2026, 4:41 PM UTC (4b73330)">Diff</a>