### PR TITLE
GH-102 start on explaining with non conforming RDF 1.1 parsers

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -4157,8 +4157,7 @@ to this sequence to give an xsd:string <em>x</em>.</li>
     <h2>Parsing RDF/XML 1.2 with non-conforming RDF/XML 1.1 parsers</h2>
 
     <p>RDF Version 1.2 introduces support for the new <a data-cite="RDF12-CONCEPTS#dfn-triple-term">Triple Terms</a>.
-    A conforming RDF/XML 1.1 parser would not see these because it should have stopped with an error due to the introduction of new attributes on the ROOT element, which was illegal. A number of mostly compliant parsers exist and do not error out here, they instead
-    mis-interpret the <code>rdf:parseType="Triple"</code> parse type as the default <code>rdf:parseType=""</code>.
+    A conforming RDF/XML 1.1 parser would not see these because it should have stopped with an error due to the introduction of new attributes on the ROOT element, which was illegal. Some almost compliant parsers exist and do not error out here, they instead mis-interpret the <code>rdf:parseType="Triple"</code> parse type as the default <code>rdf:parseType=""</code>.
     </p>
 
     <pre class="example rdf" id="confusion_example1"
@@ -4198,7 +4197,31 @@ to this sequence to give an xsd:string <em>x</em>.</li>
       -->
     </pre>
 
-    <p>This can be detected with the following SHACL shape</p>
+    <section class="informative" id="nonconforming-detect-using-shacl">
+    <h1>SHACL shape to detect some non-conforming parse results</h1>
+    <p>This can be detected with the <a href="shacl-detect-nonconforming">following</a> [[SHACL]] shape</p>
+    <pre class="example rdf"
+        data-transform="updateExample"
+        id="shacl-detect-nonconforming"
+         title="SHACL shape to detect mis-interpreted RDF/XML 1.2">
+         <!--
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:sh="http://www.w3.org/ns/shacl#">
+  <sh:NodeShape>
+    <sh:property rdf:parseType="Resource">
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</sh:maxCount>
+      <sh:name>rdf:annotation as a predicate instead of an XML attribute leading to a TripleTerm</sh:name>
+      <sh:path rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#annotation"/>
+    </sh:property>
+    <sh:targetSubjectsOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#annotation"/>
+  </sh:NodeShape>
+</rdf:RDF>
+         -->
+    </pre>
+    </section>
+
+
 </section>
 <!-- THIRTEENTH PART : Syntax Schemas -->
 <section id="section-Schemas" class="appendix informative">

--- a/spec/index.html
+++ b/spec/index.html
@@ -4152,7 +4152,55 @@ to this sequence to give an xsd:string <em>x</em>.</li>
   </ul>
 </section>
 
-<!-- TWELVETH PART : Syntax Schemas -->
+<!-- TWELVETH PART : Parsing RDF/XML 1.2 with non-conforming RDF/XML 1.1 parser-->
+<section id="nonconforming-1-1" class="appendix informative">
+    <h2>Parsing RDF/XML 1.2 with non-conforming RDF/XML 1.1 parsers</h2>
+
+    <p>RDF Version 1.2 introduces support for the new <a data-cite="RDF12-CONCEPTS#dfn-triple-term">Triple Terms</a>.
+    A conforming RDF/XML 1.1 parser would not see these because it should have stopped with an error due to the introduction of new attributes on the ROOT element, which was illegal. A number of mostly compliant parsers exist and do not error out here, they instead
+    mis-interpret the <code>rdf:parseType="Triple"</code> parse type as the default <code>rdf:parseType=""</code>.
+    </p>
+
+    <pre class="example rdf" id="confusion_example1"
+         data-transform="updateExample"
+         title="RDF/XML 1.2 example">
+      <!--
+      <rdf:RDF xmlns:ex="http://example.org/"
+                 xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                 rdf:version="1.2"
+                 xml:base="http://example.org/">
+        <rdf:Description>
+            <ex:something rdf:annotation="xyz"/>
+        </rdf:Description>
+      </rdf:RDF>
+      -->
+    </pre>
+
+    <p>In RDF/XML 1.1 this would be interepreted as shown in <a href="#confused_example1nt">this example</a></p>
+
+    <pre class="example rdf" id="confused_example1nt"
+         data-transform="updateExample"
+         title="Mis-interepreted RDF/XML 1.2">
+      <!--
+      _:1 <http://example.org/something> _:2 .
+      _:2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#>annotation> "xyz" .
+      -->
+    </pre>
+
+    <p>Instead of the correct RDF 1.2 interpretation as shown in <a href="#unconfused_example1nt">this example</a> </p>
+
+    <pre class="example rdf" id="unconfused_example1nt"
+         data-transform="updateExample"
+         title="Correctly-interepreted RDF/XML 1.2">
+      <!--
+      VERSION                                                     "1.2"
+      <<( _:1 <http://example.org/something> "xyz" )>>.
+      -->
+    </pre>
+
+    <p>This can be detected with the following SHACL shape</p>
+</section>
+<!-- THIRTEENTH PART : Syntax Schemas -->
 <section id="section-Schemas" class="appendix informative">
     <h2>Syntax Schemas</h2>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/pull/103.html" title="Last updated on Jun 1, 2026, 5:34 PM UTC (c80243a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/103/23c5e6d...c80243a.html" title="Last updated on Jun 1, 2026, 5:34 PM UTC (c80243a)">Diff</a>