### PR TITLE
Remove Macintosh file type code in media type section.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1327,7 +1327,7 @@
   </dl>
 
   <section id="section-MIME-Type">
-    <h2>RDF/XML Internet Media Type, File Extension, and Macintosh File Type</h2>
+    <h2>RDF/XML Internet Media Type and File Extension</h2>
     <dl>
       <dt>Contact:</dt>
       <dd>Dan Brickley</dd>
@@ -1342,10 +1342,6 @@
 
     <p>It is recommended that RDF/XML files have the extension &quot;.rdf&quot;
       (all lowercase) on all platforms.</p>
-
-    <p>It is recommended that RDF/XML files stored on Macintosh HFS file
-      systems be given a file type of <code>"rdf&nbsp;"</code>
-      (all lowercase, with a space character as the fourth letter).</p>
 
     <p>Features introduced in RDF 1.2 require a version announcement
       on an in-scope <a>node element</a> with an `rdf:version` attribute


### PR DESCRIPTION
w3c/rdf-star-wg#194


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/pull/114.html" title="Last updated on Jun 12, 2026, 3:29 PM UTC (2ae5ca8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/114/ba17637...2ae5ca8.html" title="Last updated on Jun 12, 2026, 3:29 PM UTC (2ae5ca8)">Diff</a>