### PR TITLE
Fix and reformat the `propertyAttr` RNC exclusion list

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -4360,13 +4360,25 @@ to this sequence to give an xsd:string <em>x</em>.</li>
       }
 
     propertyAttr =
-      attribute * - ( local:* | rdf:RDF | rdf:ID |
-                      rdf:annotation | rdf:annotationNodeID |
-                      rdf:about | rdf:parseType |
-                      rdf:resource | rdf:nodeID | rdf:datatype | rdf:version |
-                      rdf:li | its:dir | | its:version
-                      rdf:Description | rdf:aboutEach |
-                      rdf:aboutEachPrefix | rdf:bagID |
+      attribute * - (
+                      local:* |
+                      rdf:RDF |
+                      rdf:ID |
+                      rdf:annotation |
+                      rdf:annotationNodeID |
+                      rdf:about |
+                      rdf:parseType |
+                      rdf:resource |
+                      rdf:nodeID |
+                      rdf:datatype |
+                      rdf:version |
+                      rdf:li |
+                      its:dir |
+                      its:version |
+                      rdf:Description |
+                      rdf:aboutEach |
+                      rdf:aboutEachPrefix |
+                      rdf:bagID |
                       xml:* ) {
           string
       }


### PR DESCRIPTION
# Fix syntax error in `propertyAttr` RNC exclusion list

Issue: https://github.com/w3c/rdf-xml/issues/104

Suggested branch: `issue104`

## PR title

Fix and reformat the `propertyAttr` RNC exclusion list

## PR body

This fixes a syntax error in the informative RELAX NG Compact schema.

The `propertyAttr` name-class exclusion currently contains `its:dir | | its:version`, which makes the RNC invalid. This PR removes the duplicate separator and reformats the exclusion list so future separator mistakes are easier to spot.

Closes #104.

## Proposed diff

```diff
diff --git a/spec/index.html b/spec/index.html
--- a/spec/index.html
+++ b/spec/index.html
@@
-    propertyAttr =
-      attribute * - ( local:* | rdf:RDF | rdf:ID |
-                      rdf:annotation | rdf:annotationNodeID |
-                      rdf:about | rdf:parseType |
-                      rdf:resource | rdf:nodeID | rdf:datatype | rdf:version |
-                      rdf:li | its:dir | | its:version
-                      rdf:Description | rdf:aboutEach |
-                      rdf:aboutEachPrefix | rdf:bagID |
-                      xml:* ) {
+    propertyAttr =
+      attribute * - (
+                      local:* |
+                      rdf:RDF |
+                      rdf:ID |
+                      rdf:annotation |
+                      rdf:annotationNodeID |
+                      rdf:about |
+                      rdf:parseType |
+                      rdf:resource |
+                      rdf:nodeID |
+                      rdf:datatype |
+                      rdf:version |
+                      rdf:li |
+                      its:dir |
+                      its:version |
+                      rdf:Description |
+                      rdf:aboutEach |
+                      rdf:aboutEachPrefix |
+                      rdf:bagID |
+                      xml:* ) {
           string
       }
```

## Validation

The proposed change was tested with `trang` and `jing`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/pull/116.html" title="Last updated on Jun 16, 2026, 6:15 PM UTC (e505d90)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/116/3afdaba...e505d90.html" title="Last updated on Jun 16, 2026, 6:15 PM UTC (e505d90)">Diff</a>