### PR TITLE
Define `annotationAttr` and `annotationNodeIDAttr` in the RNC schema

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -4359,6 +4359,16 @@ to this sequence to give an xsd:string <em>x</em>.</li>
           IRI
       }
 
+    annotationAttr =
+      attribute rdf:annotation {
+          IRI
+      }
+
+    annotationNodeIDAttr =
+      attribute rdf:annotationNodeID {
+          IDsymbol
+      }
+
     propertyAttr =
       attribute * - ( local:* | rdf:RDF | rdf:ID |
                       rdf:annotation | rdf:annotationNodeID |


### PR DESCRIPTION
# Define annotation attribute patterns in the RNC schema

Issue: https://github.com/w3c/rdf-xml/issues/105

Suggested branch: `issue105`

## PR title

Define `annotationAttr` and `annotationNodeIDAttr` in the RNC schema

## PR body

The informative RELAX NG Compact schema uses `annotationAttr` and `annotationNodeIDAttr` in several property-element productions, but the patterns are not defined in the schema.

This adds RNC definitions aligned with the existing normative grammar productions:

- `rdf:annotation` carries an IRI.
- `rdf:annotationNodeID` carries an RDF/XML blank node identifier.

Closes #105.

## Proposed diff

```diff
diff --git a/spec/index.html b/spec/index.html
--- a/spec/index.html
+++ b/spec/index.html
@@
     aboutAttr =
       attribute rdf:about {
           IRI
       }
 
+    annotationAttr =
+      attribute rdf:annotation {
+          IRI
+      }
+
+    annotationNodeIDAttr =
+      attribute rdf:annotationNodeID {
+          IDsymbol
+      }
+
     propertyAttr =
       attribute * - ( local:* | rdf:RDF | rdf:ID |
                       rdf:annotation | rdf:annotationNodeID |
```

## Validation

The proposed change was tested with `trang` and `jing`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/pull/117.html" title="Last updated on Jun 16, 2026, 6:16 PM UTC (a45de5a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/117/3afdaba...a45de5a.html" title="Last updated on Jun 16, 2026, 6:16 PM UTC (a45de5a)">Diff</a>