### PR TITLE
Use `parseTriple` in `parseTypeTriplePropertyElt`

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -4307,7 +4307,7 @@ to this sequence to give an xsd:string <em>x</em>.</li>
                     its:dir | its:version |
                     rdf:Description | rdf:aboutEach | rdf:aboutEachPrefix | rdf:bagID |
                     xml:* ) {
-          idAttr?, (annotationAttr | annotationNodeIDAttr)?, parseResource, xmllang?, xmlbase?, versionAttr?, dirAttr?, itsVersionAttr?, propertyEltList
+          idAttr?, (annotationAttr | annotationNodeIDAttr)?, parseTriple, xmllang?, xmlbase?, versionAttr?, dirAttr?, itsVersionAttr?, propertyEltList
       }
 
     parseTypeCollectionPropertyElt =


### PR DESCRIPTION
# Use `parseTriple` in `parseTypeTriplePropertyElt`

Issue: https://github.com/w3c/rdf-xml/issues/106

Suggested branch: `issue106`

## PR title

Use `parseTriple` in `parseTypeTriplePropertyElt`

## PR body

The informative RELAX NG Compact schema currently defines `parseTypeTriplePropertyElt` with `parseResource`, so it accepts `rdf:parseType="Resource"` instead of `rdf:parseType="Triple"`.

This changes that production to use the existing `parseTriple` pattern.

Closes #106.

## Proposed diff

```diff
diff --git a/spec/index.html b/spec/index.html
--- a/spec/index.html
+++ b/spec/index.html
@@
     parseTypeTriplePropertyElt =
       element * - ( local:* | rdf:RDF | rdf:about | rdf:parseType |
                     rdf:resource | rdf:nodeID | rdf:datatype | rdf:version |
                     its:dir | its:version |
                     rdf:Description | rdf:aboutEach | rdf:aboutEachPrefix | rdf:bagID |
                     xml:* ) {
-          idAttr?, (annotationAttr | annotationNodeIDAttr)?, parseResource, xmllang?, xmlbase?, versionAttr?, dirAttr?, itsVersionAttr?, propertyEltList
+          idAttr?, (annotationAttr | annotationNodeIDAttr)?, parseTriple, xmllang?, xmlbase?, versionAttr?, dirAttr?, itsVersionAttr?, propertyEltList
       }
```

## Validation

The proposed change was tested with `trang` and `jing`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/pull/118.html" title="Last updated on Jun 16, 2026, 6:16 PM UTC (b831780)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/118/3afdaba...b831780.html" title="Last updated on Jun 16, 2026, 6:16 PM UTC (b831780)">Diff</a>