### PR TITLE
Exclude `rdf:parseType="Triple"` from `parseOther`

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -2801,7 +2801,7 @@
     <td><a href="#parseOther"></a></td> <td>attribute(<a href="#eventterm-attribute-URI">IRI</a> == <code>rdf:parseType</code>,
 
     <a
-    href="#eventterm-attribute-string-value">string-value</a> == <a>anyString</a> - ("Resource" | "Literal" | "Collection") )</td>
+    href="#eventterm-attribute-string-value">string-value</a> == <a>anyString</a> - ("Resource" | "Literal" | "Collection" | "Triple") )</td>
     </tr>
     <tr>
     <td><a href="#URI-reference"></a></td> <td>An <a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a>.</td>
@@ -3894,7 +3894,7 @@ to this sequence to give an xsd:string <em>x</em>.</li>
     <div class="productionOuter"><div class="productionInner"><p>
     attribute(<a href="#eventterm-attribute-URI">IRI</a> == <code>rdf:parseType</code>,<br />
     &#160;&#160;&#160;&#160;<a
-    href="#eventterm-attribute-string-value">string-value</a> == <a>anyString</a> - ("Resource" | "Literal" | "Collection") )
+    href="#eventterm-attribute-string-value">string-value</a> == <a>anyString</a> - ("Resource" | "Literal" | "Collection" | "Triple") )
 
     </p></div></div>
     </section>
@@ -4403,7 +4403,7 @@ to this sequence to give an xsd:string <em>x</em>.</li>
 
     parseOther =
       attribute rdf:parseType {
-          text
+          xsd:string - ( "Resource" | "Literal" | "Collection" | "Triple" )
       }
 
     versionAttr =


### PR DESCRIPTION
# Exclude `Triple` from `parseOther`

Issue: https://github.com/w3c/rdf-xml/issues/107

Suggested branch: `issue107`

## PR title

Exclude `rdf:parseType="Triple"` from `parseOther`

## PR body

The prose for `parseTypeOtherPropertyElt` says that parseType values other than `"Resource"`, `"Literal"`, `"Collection"`, or `"Triple"` are treated as `"Literal"`.

The formal `parseOther` production and the grammar summary currently exclude only the RDF 1.1 values, and the informative RNC schema accepts any text value. This PR updates both grammar occurrences and the RNC schema so `parseOther` no longer matches `"Triple"`.

Closes #107.

## Proposed diff

```diff
diff --git a/spec/index.html b/spec/index.html
--- a/spec/index.html
+++ b/spec/index.html
@@
-    href="#eventterm-attribute-string-value">string-value</a> == <a>anyString</a> - ("Resource" | "Literal" | "Collection") )</td>
+    href="#eventterm-attribute-string-value">string-value</a> == <a>anyString</a> - ("Resource" | "Literal" | "Collection" | "Triple") )</td>
@@
-    href="#eventterm-attribute-string-value">string-value</a> == <a>anyString</a> - ("Resource" | "Literal" | "Collection") )
+    href="#eventterm-attribute-string-value">string-value</a> == <a>anyString</a> - ("Resource" | "Literal" | "Collection" | "Triple") )
@@
     parseOther =
       attribute rdf:parseType {
-          text
+          xsd:string - ( "Resource" | "Literal" | "Collection" | "Triple" )
       }
```

## Validation

The proposed change was tested with `trang` and `jing`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/pull/119.html" title="Last updated on Jun 16, 2026, 6:16 PM UTC (aceb54f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/119/3afdaba...aceb54f.html" title="Last updated on Jun 16, 2026, 6:16 PM UTC (aceb54f)">Diff</a>