### PR TITLE
Allow `its:dir` on node elements and constrain its values

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -611,8 +611,9 @@
       This is specified by adding the `its:dir` attribute on any
       <a>node element</a> or <a>property element</a>, where `its` is the typical prefix
       used for the ITS namespace `http://www.w3.org/2005/11/its`.
-      The supported values for `its:dir` are `"ltr"`, and `"rtl"`
-      as required for <a data-cite="RDF12-CONCEPTS#dfn-dir-lang-string">directional language-tagged strings</a>.</p>
+      The supported values for `its:dir` are `"ltr"` and `"rtl"`
+      as required for <a data-cite="RDF12-CONCEPTS#dfn-dir-lang-string">directional language-tagged strings</a>;
+      the empty string is also allowed to clear an inherited base direction.</p>
 
     <p>Some examples of marking base direction for RDF properties are shown in
       <a href="#example9"></a>:</p>
@@ -4227,7 +4228,7 @@ to this sequence to give an xsd:string <em>x</em>.</li>
       element * - ( local:* | rdf:RDF | rdf:ID | rdf:about | rdf:parseType |
                     rdf:resource | rdf:nodeID | rdf:datatype | rdf:li |
                     rdf:aboutEach | rdf:aboutEachPrefix | rdf:bagID ) {
-          (idAttr | nodeIdAttr | aboutAttr )?, xmllang?, xmlbase?, propertyAttr*, propertyEltList
+          (idAttr | nodeIdAttr | aboutAttr )?, xmllang?, xmlbase?, dirAttr?, propertyAttr*, propertyEltList
       }
 
       # It is not possible to say "and not things
@@ -4413,7 +4414,7 @@ to this sequence to give an xsd:string <em>x</em>.</li>
 
     dirAttr =
       attribute its:dir {
-          text
+          "ltr" | "rtl" | ""
       }
 
     itsVersionAttr =


### PR DESCRIPTION
# Allow and constrain `its:dir`

Issue: https://github.com/w3c/rdf-xml/issues/109

Suggested branch: `issue109`

## PR title

Allow `its:dir` on node elements and constrain its values

## PR body

RDF/XML 1.2 says `its:dir` may be used on node elements and property elements, but the informative RELAX NG Compact schema currently allows `dirAttr?` only on property-element productions.

This PR adds `dirAttr?` to node elements and constrains `dirAttr` to the values supported by the processing model. The empty string is included because the element-event processing model already says `its:dir` must be one of `"ltr"`, `"rtl"`, or the empty string.

Closes #109.

## Proposed diff

```diff
diff --git a/spec/index.html b/spec/index.html
--- a/spec/index.html
+++ b/spec/index.html
@@
-      The supported values for `its:dir` are `"ltr"`, and `"rtl"`
-      as required for <a data-cite="RDF12-CONCEPTS#dfn-dir-lang-string">directional language-tagged strings</a>.</p>
+      The supported values for `its:dir` are `"ltr"` and `"rtl"`
+      as required for <a data-cite="RDF12-CONCEPTS#dfn-dir-lang-string">directional language-tagged strings</a>;
+      the empty string is also allowed to clear an inherited base direction.</p>
@@
     nodeElement =
       element * - ( local:* | rdf:RDF | rdf:ID | rdf:about | rdf:parseType |
                     rdf:resource | rdf:nodeID | rdf:datatype | rdf:li |
                     rdf:aboutEach | rdf:aboutEachPrefix | rdf:bagID ) {
-          (idAttr | nodeIdAttr | aboutAttr )?, xmllang?, xmlbase?, propertyAttr*, propertyEltList
+          (idAttr | nodeIdAttr | aboutAttr )?, xmllang?, xmlbase?, dirAttr?, propertyAttr*, propertyEltList
       }
@@
     dirAttr =
       attribute its:dir {
-          text
+          "ltr" | "rtl" | ""
       }
```

## Validation

The proposed change was tested with `trang` and `jing`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/pull/121.html" title="Last updated on Jun 16, 2026, 6:16 PM UTC (b0fef27)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/121/3afdaba...b0fef27.html" title="Last updated on Jun 16, 2026, 6:16 PM UTC (b0fef27)">Diff</a>