### PR TITLE
Allow `its:version="2.0"` on top-level RDF/XML elements

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -4209,12 +4209,19 @@ to this sequence to give an xsd:string <em>x</em>.</li>
     # and to forbid every other xml:* attribute, element
 
     doc =
-      RDF | nodeElement
+      RDF | topLevelNodeElement
 
     RDF =
       element rdf:RDF {
-         xmllang?, xmlbase?, nodeElementList
+         xmllang?, xmlbase?, itsVersionAttr?, nodeElementList
     }
+
+    topLevelNodeElement =
+      element * - ( local:* | rdf:RDF | rdf:ID | rdf:about | rdf:parseType |
+                    rdf:resource | rdf:nodeID | rdf:datatype | rdf:li |
+                    rdf:aboutEach | rdf:aboutEachPrefix | rdf:bagID ) {
+          (idAttr | nodeIdAttr | aboutAttr )?, xmllang?, xmlbase?, itsVersionAttr?, propertyAttr*, propertyEltList
+      }
 
     nodeElementList =
       nodeElement*
@@ -4418,7 +4425,7 @@ to this sequence to give an xsd:string <em>x</em>.</li>
 
     itsVersionAttr =
       attribute its:version {
-          text
+          "2.0"
       }
 
     IRI =


### PR DESCRIPTION
# Allow and constrain `its:version`

Issue: https://github.com/w3c/rdf-xml/issues/110

Suggested branch: `issue110`

## PR title

Allow `its:version="2.0"` on top-level RDF/XML elements

## PR body

The RDF/XML 1.2 text ties `its:dir` to ITS 2.0 through `its:version="2.0"` on the top-level XML document element. The informative RELAX NG Compact schema currently does not allow `itsVersionAttr?` on `rdf:RDF`, and the `itsVersionAttr` pattern accepts arbitrary text.

This PR allows `itsVersionAttr?` on `rdf:RDF` and adds a top-level node-element production so RDF/XML documents without an `rdf:RDF` wrapper can also carry `its:version="2.0"` on the document element without allowing it on every nested node element. It also constrains `itsVersionAttr` to `"2.0"`.

Closes #110.

## Proposed diff

```diff
diff --git a/spec/index.html b/spec/index.html
--- a/spec/index.html
+++ b/spec/index.html
@@
     doc =
-      RDF | nodeElement
+      RDF | topLevelNodeElement
 
     RDF =
       element rdf:RDF {
-         xmllang?, xmlbase?, nodeElementList
+         xmllang?, xmlbase?, itsVersionAttr?, nodeElementList
     }
 
+    topLevelNodeElement =
+      element * - ( local:* | rdf:RDF | rdf:ID | rdf:about | rdf:parseType |
+                    rdf:resource | rdf:nodeID | rdf:datatype | rdf:li |
+                    rdf:aboutEach | rdf:aboutEachPrefix | rdf:bagID ) {
+          (idAttr | nodeIdAttr | aboutAttr )?, xmllang?, xmlbase?, itsVersionAttr?, propertyAttr*, propertyEltList
+      }
+
     nodeElementList =
       nodeElement*
@@
     itsVersionAttr =
       attribute its:version {
-          text
+          "2.0"
       }
```

## Validation

The proposed change was tested with `trang` and `jing`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/pull/122.html" title="Last updated on Jun 16, 2026, 6:16 PM UTC (cddf674)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/122/3afdaba...cddf674.html" title="Last updated on Jun 16, 2026, 6:16 PM UTC (cddf674)">Diff</a>