### PR TITLE
add text for non-conformant documents

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1358,8 +1358,9 @@
   
   <section id="non-conformant-documents">
     <h3>Non-conformant Documents</h3>
-  <p> If the target of a parsing process does not conform to the requirements specified in <a href="#section-MIME-Type">RDF media type</a>, the result
-    is not defined by this specification.
+    <p> If the target of a parsing process does not conform to the requirements specified in sections
+      <a href="#section-MIME-Type"  class="sectionRef"></a>,
+      and <a href="#section-Data-Model" class="sectionRef"></a>, the result is not defined by this specification.
     Error detection, reporting, and recovery are left to implementors,
     because the appropriate behavior depends on the application interfaces and protocols within which the parser is used.
     </p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1355,6 +1355,16 @@
     <p>The `application/rdf+xml` media type has been registered at IANA as [[RFC3870]].</p>
   </section>
 
+  
+  <section id="non-conformant-documents">
+    <h3>Non-conformant Documents</h3>
+  <p> If the target of a parsing process does not conform to the requirements specified in <a href="#section-MIME-Type">RDF media type</a>, the result
+    is not defined by this specification.
+    Error detection, reporting, and recovery are left to implementors,
+    because the appropriate behavior depends on the application interfaces and protocols within which the parser is used.
+    </p>
+  </section>
+
   <section class="informative" id="privacy-considerations">
     <h2>Privacy Considerations</h2>
     <p>The RDF/XML format is used to express arbitrary application data,


### PR DESCRIPTION
align with the text from rdf-n-triples document.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/datagraph/rdf-xml/pull/124.html" title="Last updated on Sep 11, 2026, 11:00 PM UTC (2100971)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-xml/124/839c9b3...datagraph:2100971.html" title="Last updated on Sep 11, 2026, 11:00 PM UTC (2100971)">Diff</a>